### PR TITLE
Credit Card dollar added to the Bank component

### DIFF
--- a/src/components/Bank.js
+++ b/src/components/Bank.js
@@ -10,12 +10,16 @@ export default function Bank({ bank: { name, sell, buy } }) {
       <h1 className={styles.name}>{name}</h1>
       <div className={styles.exchange}>
         <p>
+          Compra
+          <span>{buy}</span>
+        </p>
+        <p>
           Venta
           <span>{sell}</span>
         </p>
         <p>
-          Compra
-          <span>{buy}</span>
+          Dolar Tarjeta
+          <span>{calculateTaxes(sell)}</span>
         </p>
       </div>
     </div>
@@ -31,6 +35,16 @@ function hasExchange(sell, buy) {
   }
 
   return true;
+}
+
+function calculateTaxes(price) {
+  const VAT = 21;
+  const SERVICES_TAXES = 8;
+  const PROFITS_TAXES = 35;
+  const TAXES = VAT + SERVICES_TAXES + PROFITS_TAXES;
+  const priceFloat = Number.parseFloat(price);
+
+  return priceFloat + priceFloat * TAXES / 100;
 }
 
 Bank.propTypes = {


### PR DESCRIPTION
### In order to show the value that each bank is charging with taxes on your credit card we must need to add a new kind of dollar: "Dolar Tarjeta"
![image](https://user-images.githubusercontent.com/4787484/97395455-c18f1080-18c3-11eb-8fcf-8cd8eed0a2ec.png)

Calculation of "Dolar Tarjeta":
- VAT of 21%
- Charge for use of external services 8%
- Profit taxes 30% (The government posted an official communication that this tax could be recovered in the next year)



Edit:

#### Different government communications regarding taxes to dollar cc:
- VAT [law communication](http://biblioteca.afip.gob.ar/dcp/REAG01004240_2018_05_11).
- External services tax [law communication](https://www.boletinoficial.gob.ar/detalleAviso/primera/224404/20200107) (aka "Impuesto Solidario" or "Impuesto Pais").
- Profit taxes [law communication](https://www.boletinoficial.gob.ar/detalleAviso/primera/235038/20200916).